### PR TITLE
Adapt the new macOS 15 window API

### DIFF
--- a/MenuHelper/ContentView.swift
+++ b/MenuHelper/ContentView.swift
@@ -65,6 +65,7 @@ struct ContentView: View {
             .foregroundStyle(.accent)
         }
         .formStyle(.grouped)
+        .scrollBounceBehavior(.basedOnSize)
     }
 }
 

--- a/MenuHelper/MenuHelperApp.swift
+++ b/MenuHelper/MenuHelperApp.swift
@@ -14,8 +14,10 @@ struct MenuHelperApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .toolbar(removing: .title)
         }
-        .defaultSize(width: 500, height: 350)
+        .windowToolbarLabelStyle(fixed: .iconOnly)
+        .defaultSize(width: 600, height: 400)
         .defaultPosition(.center)
         .commands {
             CommandGroup(replacing: .newItem) {}
@@ -35,10 +37,18 @@ struct MenuHelperApp: App {
             }
         }
         .defaultSize(width: 400, height: 300)
+        .restorationBehavior(.disabled)
         
         Window("Support", id: "support") {
             SupportWindow()
+                .frame(width: 600, height: 400)
+                .toolbar(removing: .title)
+                .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
+                .containerBackground(.thickMaterial, for: .window)
+                .windowMinimizeBehavior(.disabled)
         }
+        .windowResizability(.contentSize)
+        .restorationBehavior(.disabled)
         .handlesExternalEvents(matching: Set(arrayLiteral: "support"))
         .commands {
             CommandGroup(after: .appSettings) {
@@ -47,8 +57,6 @@ struct MenuHelperApp: App {
                 }
             }
         }
-        .defaultPosition(.center)
-        .defaultSize(width: 500, height: 300)
         
         Settings {
             SettingView()


### PR DESCRIPTION
Close #7 

Old:
<img width="612" alt="SCR-20240921-bfja" src="https://github.com/user-attachments/assets/0e3f5a4f-212f-4a18-852f-fd7727a4f92d">

New:
<img width="712" alt="SCR-20240921-bfcg" src="https://github.com/user-attachments/assets/674a8e35-d58f-4b22-b4c2-e9476a121a6a">
